### PR TITLE
docs: capitalize Jekyll page heading

### DIFF
--- a/jekyll-site/index.md
+++ b/jekyll-site/index.md
@@ -3,7 +3,7 @@ layout: default
 title: Simple Jekyll Page
 ---
 
-# Welcome to the Jekyll page
+# Welcome to the Jekyll Page
 
 This is a simple page built with **Jekyll**. It demonstrates how Jekyll can turn Markdown files into static websites using a layout. The layout file is located in `_layouts/default.html` and defines the basic HTML skeleton. 
 


### PR DESCRIPTION
## Summary
- capitalize Jekyll Page heading for consistency

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6890752d3fec83318dd274d11dfb12cb