### PR TITLE
docs: expand project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-https://tleety.github.io/Chatgpt-Test-webpage/
+# ChatGPT Test Webpage
+
+This repository hosts a small GitHub Pages site that links to a few minimal web projects.
+View the site live at https://tleety.github.io/Chatgpt-Test-webpage/.
+
+## Projects
+
+- **Simple Jekyll Project** – Markdown rendered using Jekyll.
+- **Simple Phaser Game** – Phaser 3 example with a bouncing logo.
+- **Go WASM Game** – Tiny Go WebAssembly demo that moves a square with the arrow keys.
+
+## Running locally
+
+1. **Open the landing page**
+   ```
+   open index.html
+   ```
+   This lets you click through to each project.
+
+2. **Run the Jekyll site**
+   ```
+   cd jekyll-site
+   jekyll serve
+   ```
+   Requires a Ruby environment with Jekyll installed.
+
+3. **Run the Phaser demo**
+   ```
+   open phaser-game/index.html
+   ```
+   It loads Phaser from a CDN, so no build step is necessary.
+
+4. **Build the Go WASM demo**
+   ```
+   cd go-wasm-game
+   GOOS=js GOARCH=wasm go build -o game.wasm
+   ```
+   After building, serve the folder with any static web server and open `index.html` in a browser.
+
+## License
+
+The Go runtime file `wasm_exec.js` is licensed under the BSD-style license from the Go authors.


### PR DESCRIPTION
## Summary
- document the GitHub Pages project and its subdirectories
- add instructions for running Jekyll, Phaser, and Go WASM demos locally
- note BSD license for Go's `wasm_exec.js`

## Testing
- `go test ./...` *(fails: directory prefix . does not contain main module)*
- `npm test` *(fails: no package.json found)*

------
https://chatgpt.com/codex/tasks/task_e_6890b1ec058083318b5f51978f20a4a7