### PR TITLE
Fix broken WASM game without shipping binary

### DIFF
--- a/go-wasm-game/index.html
+++ b/go-wasm-game/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Go WASM Game</title>
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
     <style>
       canvas {
         border: 1px solid #000;
@@ -16,9 +17,20 @@
     <script src="wasm_exec.js"></script>
     <script>
       const go = new Go();
-      WebAssembly.instantiateStreaming(fetch("game.wasm"), go.importObject).then((result) => {
-        go.run(result.instance);
-      });
+
+      async function loadWasm() {
+        try {
+          const result = await WebAssembly.instantiateStreaming(fetch("game.wasm"), go.importObject);
+          go.run(result.instance);
+        } catch (err) {
+          const response = await fetch("game.wasm");
+          const bytes = await response.arrayBuffer();
+          const result = await WebAssembly.instantiate(bytes, go.importObject);
+          go.run(result.instance);
+        }
+      }
+
+      loadWasm();
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- link favicon and load WASM with fetch-based fallback
- stop tracking compiled `game.wasm` and ignore future WASM artifacts

## Testing
- `GOOS=js GOARCH=wasm go build -o go-wasm-game/game.wasm go-wasm-game/main.go`
- `sha256sum go-wasm-game/game.wasm`

------
https://chatgpt.com/codex/tasks/task_e_6890b188dee88331ad870c7fac40d989