### PR TITLE
Show README on Jekyll page

### DIFF
--- a/jekyll-site/README.md
+++ b/jekyll-site/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/jekyll-site/index.md
+++ b/jekyll-site/index.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Simple Jekyll Page
+title: ChatGPT Test Webpage README
 ---
 
-# Welcome to the Jekyll Page
+{% capture readme_content %}
+{% include_relative README.md %}
+{% endcapture %}
 
-This is a simple page built with **Jekyll**. It demonstrates how Jekyll can turn Markdown files into static websites using a layout. The layout file is located in `_layouts/default.html` and defines the basic HTML skeleton. 
-
-You can edit this page by modifying `index.md` inside the `jekyll-site` folder.
+{{ readme_content | markdownify }}


### PR DESCRIPTION
## Summary
- Render root README in the Jekyll site's index using a symlink and `include_relative` so updates propagate automatically.

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 "Forbidden")*
- `apt-get update && apt-get install -y jekyll` *(fails: 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_6890b9c564808331aff7cf2d510842bb